### PR TITLE
fix path not split in windows, which cause order function work incorrectly

### DIFF
--- a/src/website-chapters-order.ts
+++ b/src/website-chapters-order.ts
@@ -40,7 +40,7 @@ export default class WebsiteChaptersOrder {
   }
 
   private static normalizeName(name: string): string {
-    return name.split('/').pop()
+    return name.split(/[\\\/]/).pop()
       ?.toLowerCase()
       .replace(/\.(.*)$/, '')
       .replace(/ /g, '-') ?? '';


### PR DESCRIPTION
Here is a example of windows path:
`C:\\Users\\xxx\\typescript-handbook-to-pdf\\temp\\TypeScript-Handbook\\pages\\Advanced Types.md`

I'm not familiar with Linux enough to affirm this patch could work under Linux, could you take a look and review.

Ref #4 